### PR TITLE
Set encoding to utf-8 when opening files

### DIFF
--- a/plover_markdown_dictionary.py
+++ b/plover_markdown_dictionary.py
@@ -179,7 +179,7 @@ class MarkdownDictionary(StenoDictionary):
         self.plover_adds_section_end_index = None
 
     def _load(self, filename):
-        with open(filename, "r") as f:
+        with open(filename, mode="r", encoding="utf-8") as f:
             lines = f.readlines()
 
         in_code_block = None
@@ -313,5 +313,5 @@ class MarkdownDictionary(StenoDictionary):
                 self.rich_lines.extend(new_adds_lines)
                 self.rich_lines.append(Prose("```\n", True))
 
-        with open(filename, "w") as f:
+        with open(filename, mode="w", encoding="utf-8") as f:
             f.write("".join([str(rich_line) for rich_line in self.rich_lines]))


### PR DESCRIPTION
After building up my steno dictionaries on macOS, I had cause to install Plover on Windows, and hence tried importing my dictionaries there. Three of them ended up being unable to be imported due to incomprehensible errors that looked like the following:

```console
'charmap' codec can't decode byte 0x90 in position 6009398:
character maps to <undefined>
```

Explicitly setting file encoding to `"utf-8"` when opening files made the errors go away, and enabled the dictionaries to be imported successfully.

Thanks for making this plugin! Pretty much all my steno dictionaries are in Markdown :)